### PR TITLE
Fix exhaustive match error for metal build

### DIFF
--- a/candle-core/src/sort.rs
+++ b/candle-core/src/sort.rs
@@ -152,6 +152,7 @@ impl crate::CustomOp1 for ArgSort {
                     DType::U32 => "asort_asc_u32",
                     DType::I64 => "asort_asc_i64",
                     DType::I32 => "asort_asc_i32",
+                    DType::I16 => "asort_asc_i16",
                 }
             } else {
                 match storage.dtype() {
@@ -163,6 +164,7 @@ impl crate::CustomOp1 for ArgSort {
                     DType::U32 => "asort_desc_u32",
                     DType::I64 => "asort_desc_i64",
                     DType::I32 => "asort_desc_i32",
+                    DType::I16 => "asort_desc_i16",
                 }
             }
         };


### PR DESCRIPTION
Compiler would error out as the match on DType was not exhaustive and missing DType::I16

This is to help address issue at https://github.com/EricLBuehler/mistral.rs/issues/778