### PR TITLE
cuda fallback bf16 for compute_cap < 8.0 (~x6 speed)

### DIFF
--- a/candle-kernels/src/binary.cu
+++ b/candle-kernels/src/binary.cu
@@ -35,6 +35,9 @@ BINARY_OP_OUT(__nv_fp8_e4m3, uint8_t, ge_f8_e4m3, F8E4M3_TO_FLOAT(x) >= F8E4M3_T
 #endif
 
 #if __CUDA_ARCH__ >= 530
+#include "cuda_bf16.h"
+BINARY_OP(__nv_bfloat16, bmul_bf16, x * y)
+BINARY_OP(__nv_bfloat16, badd_bf16, x + y)
 BINARY_OP(__half, badd_f16, x + y)
 BINARY_OP(__half, bdiv_f16, x / y)
 BINARY_OP(__half, bmul_f16, x * y)

--- a/candle-kernels/src/cast.cu
+++ b/candle-kernels/src/cast.cu
@@ -177,6 +177,12 @@ CAST_OP_FP8_INTO(__nv_bfloat16, __nv_fp8_e4m3, cast_bf16_f8_e4m3)
 #endif
 
 #if __CUDA_ARCH__ >= 530
+#include "cuda_bf16.h"
+CAST_THROUGH_OP(__nv_bfloat16, __half, float, cast_bf16_f16)
+CAST_OP(__nv_bfloat16, float,    cast_bf16_f32)
+CAST_OP(float, __nv_bfloat16, cast_f16_bf16)
+CAST_OP(float, __nv_bfloat16, cast_f32_bf16)
+
 CAST_OP(__half, __half, cast_f16_f16)
 
 CAST_THROUGH_OP(__half, uint8_t,  float, cast_f16_u8)

--- a/candle-kernels/src/compatibility.cuh
+++ b/candle-kernels/src/compatibility.cuh
@@ -39,21 +39,21 @@ __device__ double atomicAdd(double* address, double val) {
 // The 16-bit __half floating-point version of atomicAdd() is only supported by devices of compute capability 7.x and higher.
 // Solution adapted from https://github.com/torch/cutorch/blob/master/lib/THC/THCAtomics.cuh#L96-L119
 __device__ __half atomicAdd(__half *address, __half val) {
-   //  unsigned int *address_as_ui = (unsigned int *) ((char *)address - ((size_t)address & 2));
-   //  unsigned int old = *address_as_ui;
-   //  unsigned int assumed;
-   //  bool unaligned = (size_t) address & 2;
-   //  do {
-   //      assumed = old;
-   //      unsigned int hsum;
-   //      hsum = unaligned ? (old >> 16) : (old & 0xffff);
-   //      hsum = __half_as_ushort(__ushort_as_half(hsum) + val); 
-   //      old = atomicCAS(address_as_ui, assumed,
-   //          unaligned ? (old & 0xffff) | (hsum << 16) : (old & 0xffff0000) | hsum
-   //      );
+    unsigned int *address_as_ui = (unsigned int *) ((char *)address - ((size_t)address & 2));
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+    bool unaligned = (size_t) address & 2;
+    do {
+        assumed = old;
+        unsigned int hsum;
+        hsum = unaligned ? (old >> 16) : (old & 0xffff);
+        hsum = __half_as_ushort(__ushort_as_half(hsum) + val); 
+        old = atomicCAS(address_as_ui, assumed,
+            unaligned ? (old & 0xffff) | (hsum << 16) : (old & 0xffff0000) | hsum
+        );
 
-   // } while (assumed != old);
-   // return __ushort_as_half(unaligned ? (old >> 16) : (old & 0xffff));
+   } while (assumed != old);
+   return __ushort_as_half(unaligned ? (old >> 16) : (old & 0xffff));
 }
 #endif
 

--- a/candle-kernels/src/cuda_utils.cuh
+++ b/candle-kernels/src/cuda_utils.cuh
@@ -192,6 +192,8 @@ __device__ __forceinline__ uint32_t maxg(uint32_t a, uint32_t b) { return max(a,
 __device__ __forceinline__ uint8_t ming(uint8_t a, uint8_t b) { return min(a, b); }
 __device__ __forceinline__ uint8_t maxg(uint8_t a, uint8_t b) { return max(a, b); }
 #if __CUDA_ARCH__ >= 530
+#include "cuda_bf16.h"
+__device__ __forceinline__ __nv_bfloat16 maxg(__nv_bfloat16 a, __nv_bfloat16 b) { return __hmax_nan(a, b); }
 __device__ __forceinline__ __half powg(__half a, __half b) { return __float2half(powf(__half2float(a), __half2float(b))); }
 __device__ __forceinline__ bool isnang(__half a) { return __hisnan(a); }
 __device__ __forceinline__ __half sqrtg(__half a) { return hsqrt(a); }

--- a/candle-kernels/src/fill.cu
+++ b/candle-kernels/src/fill.cu
@@ -41,8 +41,10 @@ COPY2D_OP(int32_t, copy2d_i32)
 COPY2D_OP(int64_t, copy2d_i64)
 
 #if __CUDA_ARCH__ >= 530
+#include <cuda_bf16.h>
 extern "C" __global__ void fill_f16(__half *buf, __half value, const size_t numel) { fill_with(buf, value, numel); }
 COPY2D_OP(__half, copy2d_f16)
+COPY2D_OP(__nv_bfloat16, copy2d_bf16)
 #endif
 
 #if __CUDA_ARCH__ >= 800

--- a/candle-kernels/src/fused_rope.cu
+++ b/candle-kernels/src/fused_rope.cu
@@ -189,7 +189,7 @@ extern "C" __global__ void rotary_embedding_kernel_neox_f64(
   apply_rotary_embedding<double, true>(query, key, cache_ptr, head_size, num_heads, num_kv_heads, rot_dim, token_idx, query_stride, key_stride);
 }
 
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 530
 #include <cuda_bf16.h>
 extern "C" __global__ void rotary_embedding_kernel_bf16(
   const int64_t* __restrict__ positions,        // [batch_size, seq_len] or [num_tokens]
@@ -229,3 +229,4 @@ extern "C" __global__ void rotary_embedding_kernel_neox_bf16(
   apply_rotary_embedding<__nv_bfloat16, true>(query, key, cache_ptr, head_size, num_heads, num_kv_heads, rot_dim, token_idx, query_stride, key_stride);
 }
 #endif
+

--- a/candle-kernels/src/indexing.cu
+++ b/candle-kernels/src/indexing.cu
@@ -268,6 +268,8 @@ SA_OP_F8(__nv_fp8_e4m3, uint8_t, sa_u8_f8_e4m3)
 #endif
 
 #if __CUDA_ARCH__ >= 530
+#include "cuda_bf16.h"
+IS_OP(__nv_bfloat16, uint32_t, is_u32_bf16)
 IS_OP(__half, int16_t, is_i16_f16)
 IS_OP(__half, int32_t, is_i32_f16)
 IS_OP(__half, int64_t, is_i64_f16)

--- a/candle-kernels/src/kvconcat.cu
+++ b/candle-kernels/src/kvconcat.cu
@@ -45,6 +45,9 @@ KVCONCAT_OP(double, kvconcat_f64)
 KVCONCAT_OP(float, kvconcat_f32)
 
 #if __CUDA_ARCH__ >= 530
+#include "cuda_bf16.h"
+
+KVCONCAT_OP(__nv_bfloat16, kvconcat_bf16)
 KVCONCAT_OP(__half, kvconcat_f16)
 #endif
 

--- a/candle-kernels/src/reduce.cu
+++ b/candle-kernels/src/reduce.cu
@@ -590,6 +590,10 @@ FAST_OP(__nv_bfloat16, fast_min_bf16, fast_max_bf16, fast_argmin_bf16, fast_argm
 #endif
 
 #if __CUDA_ARCH__ >= 530
+#include "cuda_bf16.h"
+ROPE_OP(__nv_bfloat16, rope_bf16, rope_i_bf16, rope_thd_bf16)
+SOFTMAX_OP(__nv_bfloat16, float, softmax_bf16)
+RMSNORM_OP(__nv_bfloat16, rmsnorm_bf16)
 SOFTMAX_OP(__half, float, softmax_f16)
 RMSNORM_OP(__half, rmsnorm_f16)
 LAYERNORM_OP(__half, layernorm_f16)

--- a/candle-kernels/src/ternary.cu
+++ b/candle-kernels/src/ternary.cu
@@ -50,6 +50,8 @@ WHERE_OP(__nv_fp8_e4m3, uint8_t, where_u8_fp8_e4m3)
 #endif
 
 #if __CUDA_ARCH__ >= 530
+#include "cuda_bf16.h"
+WHERE_OP(__nv_bfloat16, uint8_t, where_u8_bf16)
 WHERE_OP(__half, int16_t, where_i16_f16)    
 WHERE_OP(__half, int32_t, where_i32_f16)
 WHERE_OP(__half, int64_t, where_i64_f16)

--- a/candle-kernels/src/unary.cu
+++ b/candle-kernels/src/unary.cu
@@ -155,6 +155,17 @@ UNARY_OP(__nv_fp8_e4m3, usigmoid_fp8_e4m3, __nv_fp8_e4m3(sigmoid_fwd(F8E4M3_TO_F
 #endif
 
 #if __CUDA_ARCH__ >= 530
+#include "cuda_bf16.h"
+template <typename T>
+__device__ __forceinline__ T silu_fwd_fallback(T x) {
+    const T one = T(1.0f);
+    const T neg_x = -x;
+    const T exp_neg_x = expg(neg_x);
+    return x / (one + exp_neg_x);
+}
+
+UNARY_OP(__nv_bfloat16, ucopy_bf16, x)
+UNARY_OP(__nv_bfloat16, usilu_bf16,  silu_fwd_fallback(x))
 UNARY_OP(__half, ucopy_f16, x)
 UNARY_OP(__half, uneg_f16, -x)
 UNARY_OP(__half, urecip_f16, recipg(x))


### PR DESCRIPTION
tested and works with:
```
nvidia-smi   --query-gpu="compute_cap"  --format=csv
compute_cap
6.1 
```
and mistral.rs:

`cargo run -F "cuda cudnn " -r --  --no-paged-attn      -i plain -m meta-llama/Llama-3.2-1B-Instruct  --dtype bf16`

