### PR TITLE
Update cudarc crate to 0.16.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ candle-onnx = { path = "./candle-onnx", version = "0.8.0" }
 candle-transformers = { path = "./candle-transformers", version = "0.8.0" }
 clap = { version = "4.2.4", features = ["derive"] }
 criterion = { version = "0.5.1", default-features=false }
-cudarc = { version = "0.13.3", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"], default-features=false }
+cudarc = { version = "0.16.4", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"], default-features=false }
 fancy-regex = "0.13.0"
 gemm = { version = "0.17.0", features = ["wasm-simd128-enable"] }
 hf-hub = { version = "0.3.3", package = "candle-hf-hub" }


### PR DESCRIPTION
CUDA/cublas/etc interface library is getting somewhat long in the tooth compared to current CUDA releases. This is likely why 12.9 fails to build with the appropriate cotainer and may contain fix for the current matmul/cublas/drop stack traces breaking paged attention in mistralrs.

Testing:
  Local build - didn't blow up, haven't gotten to mistral tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of a core dependency to ensure compatibility and access to the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->