### PR TITLE
iOS Support for Metal Backend

### DIFF
--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -323,7 +323,6 @@ impl MetalDevice {
         }
 
         let size = buf_size(size);
-        println!("Allocating new buffer of size {size} with option {option:?}");
         let subbuffers = buffers.entry((size, option)).or_insert(vec![]);
 
         let new_buffer = self.device.new_buffer(size as NSUInteger, option);

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -323,6 +323,7 @@ impl MetalDevice {
         }
 
         let size = buf_size(size);
+        println!("Allocating new buffer of size {size} with option {option:?}");
         let subbuffers = buffers.entry((size, option)).or_insert(vec![]);
 
         let new_buffer = self.device.new_buffer(size as NSUInteger, option);
@@ -354,7 +355,8 @@ impl MetalDevice {
 }
 
 fn buf_size(size: NSUInteger) -> NSUInteger {
-    size.saturating_sub(1).next_power_of_two() as NSUInteger
+    // size.saturating_sub(1).next_power_of_two() as NSUInteger
+    size.next_power_of_two() as NSUInteger
 }
 
 fn find_available_buffer(

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -11,14 +11,7 @@ use std::ffi::c_void;
 use std::sync::{Arc, Mutex, PoisonError, RwLock, TryLockError};
 
 mod device;
-pub use device::{DeviceId, MetalDevice};
-
-// iOS and macOS have different storage modes for shared buffers.
-// due to the GPU/CPU management differences.
-#[cfg(target_os = "ios")]
-const SHARED_BUFFER_STORAGE_MODE: MTLResourceOptions = MTLResourceOptions::StorageModeShared;
-#[cfg(not(target_os = "ios"))]
-const SHARED_BUFFER_STORAGE_MODE: MTLResourceOptions = MTLResourceOptions::StorageModeManaged;
+pub use device::{DeviceId, MetalDevice, SHARED_BUFFER_STORAGE_MODE};
 
 pub fn buffer_o<'a>(buffer: &'a Buffer, l: &Layout, dtype: DType) -> BufferOffset<'a> {
     BufferOffset {

--- a/candle-metal-kernels/examples/metal_benchmarks.rs
+++ b/candle-metal-kernels/examples/metal_benchmarks.rs
@@ -13,7 +13,10 @@ fn run_gemm(f32: bool, n: usize) -> Result<()> {
     let (b, m, n, k) = (1, n, n, n);
     let kernels = candle_metal_kernels::Kernels::new();
     let command_queue = device.new_command_queue();
-    let options = metal::MTLResourceOptions::StorageModeManaged;
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
+    let options = MTLResourceOptions::StorageModeManaged;
 
     let (lhs, rhs) = if f32 {
         let lhs: Vec<f32> = (0..b * m * k).map(|f| f as f32).collect();

--- a/candle-metal-kernels/examples/metal_benchmarks.rs
+++ b/candle-metal-kernels/examples/metal_benchmarks.rs
@@ -14,9 +14,9 @@ fn run_gemm(f32: bool, n: usize) -> Result<()> {
     let kernels = candle_metal_kernels::Kernels::new();
     let command_queue = device.new_command_queue();
     #[cfg(target_os = "ios")]
-    let options = MTLResourceOptions::StorageModeShared;
+    let options = metal::MTLResourceOptions::StorageModeShared;
     #[cfg(not(target_os = "ios"))]
-    let options = MTLResourceOptions::StorageModeManaged;
+    let options = metal::MTLResourceOptions::StorageModeManaged;
 
     let (lhs, rhs) = if f32 {
         let lhs: Vec<f32> = (0..b * m * k).map(|f| f as f32).collect();

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -625,6 +625,11 @@ pub fn call_binary_strided(
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, width);
 
     encoder.set_compute_pipeline_state(&pipeline);
+
+    let dummy = &[0usize];
+    let shape = if num_dims == 0 { dummy } else { shape };
+    let left_strides = if num_dims == 0 { dummy } else { left_strides };
+    let right_strides = if num_dims == 0 { dummy } else { right_strides };
     set_params!(
         encoder,
         (

--- a/candle-metal-kernels/src/sort.rs
+++ b/candle-metal-kernels/src/sort.rs
@@ -92,11 +92,11 @@ pub fn multi_block_sort(
                 &src,
                 &mut dev_vals_0,
                 &mut dev_idxs_0,
-                /* size_sorted_axis */ ncols as i32,
-                /* stride_sorted_axis */ 1i32,
-                /* nc_dim */ 1i32,
-                /* nc_shape */ nrows as i32,
-                /* nc_str */ ncols as i32
+                /* size_sorted_axis */ ncols as i64,
+                /* stride_sorted_axis */ 1i64,
+                /* nc_dim */ 1i64,
+                /* nc_shape */ nrows as i64,
+                /* nc_str */ ncols as i64
             )
         );
         let thread_group_count = MTLSize {
@@ -243,11 +243,11 @@ pub fn block_sort(
         (
             &src,
             dst,
-            ncols as i32,
-            1i32,
-            1i32,
-            ncols as i32,
-            ncols as i32
+            ncols as i64,
+            1i64,
+            1i64,
+            ncols as i64,
+            ncols as i64
         )
     );
     let thread_group_count = MTLSize {

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -72,7 +72,10 @@ fn run_binary<T: Clone>(x: &[T], y: &[T], name: binary::contiguous::Kernel) -> V
     let kernels = Kernels::new();
     let command_queue = device.new_command_queue();
     let command_buffer = command_queue.new_command_buffer();
-    let options = SHARED_BUFFER_STORAGE_MODE;
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
+    let options = MTLResourceOptions::StorageModeManaged;
     let left = new_buffer(&device, x);
     let right = new_buffer(&device, y);
     let output = device.new_buffer(std::mem::size_of_val(x) as u64, options);
@@ -314,7 +317,10 @@ fn run_cast<T: Clone, U: Clone>(v: &[T], name: &'static str) -> Vec<U> {
     let command_queue = device.new_command_queue();
     let command_buffer = command_queue.new_command_buffer();
     let input = new_buffer(&device, v);
-    let options = SHARED_BUFFER_STORAGE_MODE;
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
+    let options = MTLResourceOptions::StorageModeManaged;
     let size = (v.len() * std::mem::size_of::<U>()) as u64;
     let output = device.new_buffer(size, options);
 
@@ -877,7 +883,10 @@ fn run_reduce<T, U: Clone>(
     let command_buffer = command_queue.new_command_buffer();
     let input = new_buffer(&device, v);
 
-    let options = SHARED_BUFFER_STORAGE_MODE;
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
+    let options = MTLResourceOptions::StorageModeManaged;
     let output = device.new_buffer((out_length * core::mem::size_of::<U>()) as u64, options);
     let shape = vec![in_length];
     match call_reduce_contiguous(
@@ -1191,7 +1200,10 @@ fn run_where_cond<I: Clone, T: Clone>(
     let kernels = Kernels::new();
     let command_queue = device.new_command_queue();
     let command_buffer = command_queue.new_command_buffer();
-    let options = SHARED_BUFFER_STORAGE_MODE;
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
+    let options = MTLResourceOptions::StorageModeManaged;
 
     let length = cond.len();
     let cond = device.new_buffer_with_data(
@@ -1302,7 +1314,10 @@ fn run_mlx_gemm<T: Clone>(
     let kernels = Kernels::new();
     let command_queue = device.new_command_queue();
     let command_buffer = command_queue.new_command_buffer();
-    let options = SHARED_BUFFER_STORAGE_MODE;
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
+    let options = MTLResourceOptions::StorageModeManaged;
 
     let lhs = device.new_buffer_with_data(
         lhs.as_ptr() as *const core::ffi::c_void,
@@ -1447,7 +1462,10 @@ fn run_random<T: Clone>(name: &'static str, seed: u32, length: usize, a: f32, b:
     let command_queue = device.new_command_queue();
     let command_buffer = command_queue.new_command_buffer();
 
-    let options = SHARED_BUFFER_STORAGE_MODE;
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
+    let options = MTLResourceOptions::StorageModeManaged;
     let output = device.new_buffer((length * core::mem::size_of::<T>()) as NSUInteger, options);
 
     let seed = device.new_buffer_with_data(
@@ -1573,7 +1591,10 @@ fn run_scatter_add<T: Clone, I: Clone + std::fmt::Debug>(
     let kernels = Kernels::new();
     let command_queue = device.new_command_queue();
     let command_buffer = command_queue.new_command_buffer();
-    let options = SHARED_BUFFER_STORAGE_MODE;
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
+    let options = MTLResourceOptions::StorageModeManaged;
     let input_buffer = new_buffer(&device, input);
     let ids_buffer = new_buffer(&device, ids);
     let output = device.new_buffer(std::mem::size_of_val(input) as u64, options);

--- a/candle-metal-kernels/tmp/affine.rs
+++ b/candle-metal-kernels/tmp/affine.rs
@@ -30,6 +30,9 @@ fn main() {
 
 fn run_affine_bench<T: Clone>(device: &Device, kernels: &Kernels, v: &[T]) {
     let command_queue = device.new_command_queue();
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
     let options = MTLResourceOptions::StorageModeManaged;
 
     let iterations = 10000;

--- a/candle-metal-kernels/tmp/binary.rs
+++ b/candle-metal-kernels/tmp/binary.rs
@@ -94,6 +94,9 @@ fn run_binary_bench<T: Clone>(
     strided: [binary::strided::Kernel; 4],
 ) {
     let command_queue = device.new_command_queue();
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
     let options = MTLResourceOptions::StorageModeManaged;
 
     let iterations = 1000;

--- a/candle-metal-kernels/tmp/cast.rs
+++ b/candle-metal-kernels/tmp/cast.rs
@@ -37,6 +37,9 @@ fn run_cast_bench<T: Clone>(
     contiguous: &[&'static str],
 ) {
     let command_queue = device.new_command_queue();
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
     let options = MTLResourceOptions::StorageModeManaged;
 
     let iterations = 1000;

--- a/candle-metal-kernels/tmp/unary.rs
+++ b/candle-metal-kernels/tmp/unary.rs
@@ -112,6 +112,9 @@ fn run_unary_bench<T: Clone>(
     strided: [unary::strided::Kernel; 7],
 ) {
     let command_queue = device.new_command_queue();
+    #[cfg(target_os = "ios")]
+    let options = MTLResourceOptions::StorageModeShared;
+    #[cfg(not(target_os = "ios"))]
     let options = MTLResourceOptions::StorageModeManaged;
 
     let iterations = 10000;


### PR DESCRIPTION
Due to crashes during either new_metal device calls or resource allocation (see [issue on Candle main](https://github.com/huggingface/candle/issues/2322))

1. Replaced references to MTLResourceOptions::StorageMode* enums to METAL_SHARED_BUFFER_STORAGE_MODE
2. Metal benchmark options are now sensitive to iOS vs MacOS

Tested working on iOS 18.2 iphone 16 pro and M4 iPad Pro